### PR TITLE
Fix the implementation of getField to match it documented behavior

### DIFF
--- a/src/Form.php
+++ b/src/Form.php
@@ -38,6 +38,10 @@ class Form
      */
     public function getField($key)
     {
+        if (!isset($this->fields[$key])) {
+            return false;
+        }
+
         return $this->fields[$key];
     }
 


### PR DESCRIPTION
The existing implementation was throwing a notice and returning `null` when getting a non-existent key.

On a side note, using `null` would be better than `false` IMO. 
